### PR TITLE
add file link to cli table output

### DIFF
--- a/Walrus.Core/WalrusCommit.cs
+++ b/Walrus.Core/WalrusCommit.cs
@@ -2,24 +2,34 @@
 {
     using LibGit2Sharp;
     using System;
+    using System.IO;
+    using Walrus.Core.Internal;
 
     /// <summary>
     /// TODO: do we want to wrap this type or use the raw LibGit2 type?
     /// </summary>
     public class WalrusCommit
     {
+        private readonly WalrusRepository _repository;
         private readonly Commit _commit;
 
-        public WalrusCommit(string repoName, Commit commit)
+        public WalrusCommit(WalrusRepository repository, Commit commit)
         {
-            RepoName = repoName;
+            Ensure.IsNotNull(nameof(repository), repository);
+            Ensure.IsNotNull(nameof(commit), commit);
+
+            _repository = repository;
             _commit = commit;
         }
+        /// <summary>
+        /// Path to repository containing this commit5
+        /// </summary>
+        public string RepoPath => _repository.RepositoryPath!;
 
         /// <summary>
         /// Name of Git repo this commit belongs to
         /// </summary>
-        public string RepoName { get; }
+        public string RepoName => _repository.RepositoryName!;
 
         /// <summary>
         /// Commit message text

--- a/Walrus.Core/WalrusRepository.cs
+++ b/Walrus.Core/WalrusRepository.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// Name of folder containing Git repo
         /// </summary>
-        public string? RepositoryName => Path.GetFileName(RepositoryPath);
+        public string RepositoryName => Path.GetFileName(RepositoryPath);
 
         /// <summary>
         /// Absolute path to Git repo
         /// </summary>
-        public string? RepositoryPath => Path.GetDirectoryName(_repository?.Info?.WorkingDirectory);
+        public string RepositoryPath => Path.GetDirectoryName(_repository?.Info?.WorkingDirectory)!;
 
         /// <summary>
         /// Most recent commit message
@@ -103,7 +103,7 @@
                 var commit = commitIter.Current;
                 if (IsMatch(commit, query))
                 {
-                    yield return new WalrusCommit(RepositoryName!, commit);
+                    yield return new WalrusCommit(this, commit);
                 }
             } while (true);
 


### PR DESCRIPTION
Add option to ctrl+click to open the repo from the console
Improve performance by using a counter instead of enumerating
the commits list twice.