### PR TITLE
add group-by option add feature #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /**/obj/**/*
 /dist/
 /Walrus.CLI/Properties/launchSettings.json
+/.idea/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ walrusc query --all-branches --author-email cory@email.com
 
 Print commit summary by repo and date to the console.
 ```
-walrusc query --author-email cory@email.com --print-table
+walrusc query --author-email cory@email.com --group-by repo
 
 Repository: uarch_benchmarks [file://H:\code\system\uarch_benchmarks]
 ----------------------------------------------------------------------------------------------------

--- a/Walrus.Core/CommitGroup.cs
+++ b/Walrus.Core/CommitGroup.cs
@@ -1,0 +1,31 @@
+﻿namespace Walrus.Core
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Query grouping wrapper allows for arbitrary key grouping
+    /// </summary>
+    public class CommitGroup
+    {
+        /// <summary>
+        /// Create a new commit group
+        /// </summary>
+        /// <param name="key">Group key</param>
+        /// <param name="data">Commits</param>
+        public CommitGroup(object key, IEnumerable<WalrusCommit> data)
+        {
+            Key = key;
+            Data = data;
+        }
+
+        /// <summary>
+        /// Grouping key
+        /// </summary>
+        public object Key { get; }
+
+        /// <summary>
+        /// Commits for this group
+        /// </summary>
+        public IEnumerable<WalrusCommit> Data { get; }
+    }
+}

--- a/Walrus.Core/IWalrusService.cs
+++ b/Walrus.Core/IWalrusService.cs
@@ -1,5 +1,6 @@
 ﻿namespace Walrus.Core
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -11,6 +12,14 @@
         /// Active configuration
         /// </summary>
         WalrusConfig Config { get; }
+
+        /// <summary>
+        /// Executes the specified query
+        /// </summary>
+        /// <param name="query">Query to run</param>
+        /// <returns>Resulting commit</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Raised if query grouping method is invalid</exception>
+        IEnumerable<CommitGroup> ExecuteQuery(WalrusQuery query);
 
         /// <summary>
         /// Returns a list of all repositories that Walrus can see

--- a/Walrus.Core/WalrusQuery.cs
+++ b/Walrus.Core/WalrusQuery.cs
@@ -47,6 +47,11 @@
         public string? RepoName { get; set; }
 
         /// <summary>
+        /// Group results using this rule
+        /// </summary>
+        public QueryGrouping GroupBy { get; set; }
+
+        /// <summary>
         /// Assign service configuration to this query which will augment
         /// certain query parameters. This includes:
         /// - the user alias feature.
@@ -99,7 +104,25 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"After={After}, Before={Before}, AllBranches={AllBranches}, Author.Email={AuthorEmail}, Author.Alias={AuthorAlias}";
+            return $"After={After}, Before={Before}, AllBranches={AllBranches}, Author.Email={AuthorEmail}, Author.Alias={AuthorAlias}, Grouping={GroupBy}";
+        }
+
+        public enum QueryGrouping
+        {
+            /// <summary>
+            /// Group commits by repo
+            /// </summary>
+            Repo,
+
+            /// <summary>
+            /// Group commits by date (specifcally by day)
+            /// </summary>
+            Date,
+
+            /// <summary>
+            /// Group commits by author email or alias
+            /// </summary>
+            Author
         }
     }
 }

--- a/Walrus.Core/WalrusService.cs
+++ b/Walrus.Core/WalrusService.cs
@@ -1,7 +1,10 @@
 ﻿namespace Walrus.Core
 {
     using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
     using Walrus.Core.Internal;
 
     /// <summary>
@@ -29,6 +32,41 @@
         public WalrusConfig Config { get; private set; }
 
         /// <inheritdoc />
+        public IEnumerable<CommitGroup> ExecuteQuery(WalrusQuery query)
+        {
+            var commits =
+                GetRepositories()
+                    .Where(r => FilterRepo(r, query))
+                    .AsParallel()
+                    .Select(r => r.GetCommits(query))
+                    .SelectMany(c => c);
+
+            // Wrap GroupBy in a CommitGroup so we can have keys of different types
+            var grouped = query.GroupBy switch
+            {
+                WalrusQuery.QueryGrouping.Repo => commits
+                    .GroupBy(c => c.RepoName)
+                    .Select(g => new CommitGroup(g.Key, 
+                        g.OrderBy(c => c.Timestamp))),
+                
+                WalrusQuery.QueryGrouping.Date => commits
+                    .GroupBy(c => c.Timestamp.Date)
+                    .Select(g => new CommitGroup(g.Key, 
+                        g.OrderBy(c => c.Timestamp))),
+                
+                WalrusQuery.QueryGrouping.Author => commits
+                    .GroupBy(c => c.AuthorEmail)
+                    .Select(g => new CommitGroup(g.Key,
+                        g.OrderBy(c => c.Timestamp))),
+                
+                _ => throw new ArgumentOutOfRangeException(nameof(query.GroupBy))
+            };
+
+            return grouped;
+        }
+
+
+        /// <inheritdoc />
         public IEnumerable<WalrusRepository> GetRepositories()
         {
             if (Config.RepositoryRoots is null)
@@ -48,6 +86,18 @@
                     yield return repository;
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns true if repository should be included in query
+        /// </summary>
+        /// <param name="repository">Repository to test</param>
+        /// <param name="query">Query parameters</param>
+        /// <returns>True if filter should be included</returns>
+        private static bool FilterRepo(WalrusRepository repository, WalrusQuery query)
+        {
+            return string.IsNullOrEmpty(query.RepoName) ||
+                   repository.RepositoryName.Equals(query.RepoName, StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
This adds a group by option for query printing. This warranted a change
to the IWalrusService interface to add a ExecuteQuery. This allows us to
perform the full query, grouping included, all within the core lib. This
leaves console rendering to the CLI.

Adds feature #3 