### PR TITLE
fix group by date issue #7

### DIFF
--- a/Walrus.Core/WalrusService.cs
+++ b/Walrus.Core/WalrusService.cs
@@ -50,6 +50,7 @@
                         g.OrderBy(c => c.Timestamp))),
                 
                 WalrusQuery.QueryGrouping.Date => commits
+                    .OrderBy(c => c.Timestamp)
                     .GroupBy(c => c.Timestamp.Date)
                     .Select(g => new CommitGroup(g.Key, 
                         g.OrderBy(c => c.Timestamp))),


### PR DESCRIPTION
Sort commits before grouping by date. Only incur the sort cost
for sorting by date.

Fix #7 