### PR TITLE
[utilities] simplify internal git enumerator

### DIFF
--- a/Walrus.Core/Internal/Utilities.cs
+++ b/Walrus.Core/Internal/Utilities.cs
@@ -2,19 +2,18 @@
 {
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using LibGit2Sharp;
 
     internal static class Utilities
     {
         /// <summary>
-        ///     Returns a list of directories contained within the specified root directory
+        ///     Returns a list of Git directories contained within the specified root directory
         ///     and its children up to the specified depth.
         /// </summary>
         /// <param name="root">Starting directory</param>
         /// <param name="depth">Scan depth. Set to zero for top-level only.</param>
         /// <returns></returns>
-        public static IEnumerable<string> EnumerateDirectoriesToDepth(string root, int depth)
+        public static IEnumerable<string> EnumerateGitDirectoriesToDepth(string root, int depth)
         {
             if (--depth <= 0)
             {
@@ -32,24 +31,12 @@
                 }
                 else
                 {
-                    foreach (var subDirectory in EnumerateDirectoriesToDepth(directory, depth))
+                    foreach (var subDirectory in EnumerateGitDirectoriesToDepth(directory, depth))
                     {
                         yield return subDirectory;
                     }
                 }
             }
-        }
-
-        /// <summary>
-        ///     Filter and return only valid Git repositories from the specified directory list
-        /// </summary>
-        /// <param name="directories">Directories to filter</param>
-        /// <returns>List of valid Git repositories</returns>
-        public static IEnumerable<IRepository> GetValidRepositories(IEnumerable<string> directories)
-        {
-            return from directory in directories
-                where Repository.IsValid(directory)
-                select new Repository(directory);
         }
     }
 }

--- a/Walrus.Core/Repository/RepositoryProvider.cs
+++ b/Walrus.Core/Repository/RepositoryProvider.cs
@@ -18,16 +18,19 @@
             Ensure.IsValid(nameof(rootDirectory), !string.IsNullOrEmpty(rootDirectory));
             Ensure.IsValid(nameof(scanDepth), scanDepth >= 0);
 
-            var directories = Utilities.EnumerateDirectoriesToDepth(rootDirectory, scanDepth);
+            var directories = Utilities.EnumerateGitDirectoriesToDepth(rootDirectory, scanDepth);
 
-            foreach (var repo in Utilities.GetValidRepositories(directories))
+            foreach (var directory in directories)
             {
+                Ensure.IsValid(nameof(directory), Repository.IsValid(directory), "There is a bug in EnumerateGitDirectoriesToDepth");
+                var repo = new Repository(directory);
+
                 // Bare repos do not set working directory, fallback to path
                 var repoPath = repo.Info.WorkingDirectory ?? repo.Info.Path;
 
                 // If neither the path or the working directory are set
                 Ensure.IsValid(nameof(repoPath), !string.IsNullOrEmpty(repoPath), "Expected a valid repo path to be set. This is a bug.");
-                
+
                 var commits = GetCommits(repo, allBranches);
 
                 var repository = new WalrusRepository(repoPath, commits);
@@ -110,7 +113,7 @@
 
                 var repoPath = repository.Info.WorkingDirectory!;
                 var repoName = Path.GetFileName(Path.GetDirectoryName(repoPath))!;
-                
+
                 var commit = iter.Current;
                 yield return new WalrusCommit
                 {


### PR DESCRIPTION
We don't need to enumerators. Just make one that is more clearly
purposed for enumerating git repositories.