### PR TITLE
Add ~/, $VAR, and %VAR% support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Walrus.CLI/Properties/launchSettings.json
 /.idea/
 /Walrus.sln.DotSettings.user
+/.vscode/

--- a/Walrus.CLI/Program.cs
+++ b/Walrus.CLI/Program.cs
@@ -19,37 +19,37 @@
         /// </summary>
         private static async Task<int> Main(string[] args)
         {
-            try
+            try 
             {
                 var serviceProvider = ConfigureServices();
 
                 var parser = BuildParser(serviceProvider);
 
-                return await parser.InvokeAsync(args).ConfigureAwait(false);
+                return await parser
+                    .InvokeAsync(args)
+                    .ConfigureAwait(false);
             }
-            catch (FileNotFoundException ex)
+            catch(WalrusConfigurationException ex)
             {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.Write("ERROR: ");
-                Console.ResetColor();
-                Console.WriteLine("Unable to find configuration file. " + Environment.NewLine +
-                                  "You can provide a configuration file in one of two ways: " + Environment.NewLine +
-                                  "1) Define an env named WALRUS_CONFIG_FILE that points to your configuration file" +
-                                  Environment.NewLine +
-                                  "2) Create a file named walrus.config in your current working directory" +
-                                  Environment.NewLine);
-                Console.WriteLine($"The original exception was: {ex.Message}");
+                WriteError("Your walrus config file is invalid", ex);
+                return -1;
+            }
+        }
 
-                return 1;
-            }
-            catch (InvalidDataException ex)
+        /// <summary>
+        /// Write error message to console in red
+        /// </summary>
+        /// <param name="message">Text to show</param>
+        /// <param name="ex">Original exception</param>
+        private static void WriteError(string message, Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write("ERROR: ");
+            Console.ResetColor();
+            Console.WriteLine(message);
+            if(ex is not null)
             {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.Write("ERROR: ");
-                Console.ResetColor();
-                Console.WriteLine("Your configuration file invalid JSON");
-                Console.WriteLine($"The original exception was: {ex.Message}");
-                return 1;
+                Console.WriteLine($"Details: {ex.Message}");
             }
         }
 
@@ -73,7 +73,42 @@
                 commandLineBuilder.AddCommand(command.Command);
             }
 
-            return commandLineBuilder.UseDefaults().Build();
+            return commandLineBuilder.UseDefaults()
+                .UseExceptionHandler((e, context) =>
+                {
+                    // Unwind to inner mode exception
+                    var innerEx = e;
+                    while(innerEx.InnerException is not null){
+                        innerEx = innerEx.InnerException;
+                    }
+
+                    switch(innerEx)
+                    {        
+                        case DirectoryNotFoundException dnfe:
+                            WriteError("One or more directories in your config file do not exist", dnfe);
+                            break;
+
+                        case FileNotFoundException fnfe:
+                            var message = "Unable to find configuration file. " + Environment.NewLine +
+                                          "You can provide a configuration file in one of two ways: " + Environment.NewLine +
+                                          "1) Define an env named WALRUS_CONFIG_FILE that points to your configuration file" +
+                                          Environment.NewLine +
+                                          "2) Create a file named walrus.config in your current working directory" +
+                                          Environment.NewLine;
+                            WriteError(message, fnfe);
+                            break;
+                        case InvalidDataException ide:
+                            WriteError("Your configuration file invalid JSON", ide);
+                            break;
+                        case Exception ex:
+                            WriteError("Exception", ex);
+                            break;
+                        default:
+                            WriteError("Unknown Error", null);
+                            break;
+                    }
+                })
+                .Build();
         }
 
         /// <summary>
@@ -83,6 +118,7 @@
         private static IServiceProvider ConfigureServices()
         {
             var configFile = Environment.GetEnvironmentVariable("WALRUS_CONFIG_FILE") ?? "walrus.json";
+            configFile = PathHelper.ResolvePath(configFile);
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(configFile, true)
                 .Build();
@@ -99,8 +135,12 @@
                     configure.AddConsole();
                 })
                 .AddSingleton<IConfiguration>(configuration)
-                .AddSingleton<IWalrusConfig>(p => p.GetRequiredService<IConfiguration>().Get<WalrusConfig>() ??
-                                                  WalrusConfig.Default)
+                .AddSingleton<IWalrusConfig>(p => {
+                    var config = p.GetRequiredService<IConfiguration>().Get<WalrusConfig>() ??
+                                                  WalrusConfig.Default;
+                    config.ValidateOrThrow();            
+                    return config;
+                })
                 .AddTransient<IRepositoryProvider, RepositoryProvider>()
                 .AddTransient<IWalrusService, WalrusService>()
                 .AddCliCommands();

--- a/Walrus.CLI/Program.cs
+++ b/Walrus.CLI/Program.cs
@@ -19,7 +19,7 @@
         /// </summary>
         private static async Task<int> Main(string[] args)
         {
-            try 
+            try
             {
                 var serviceProvider = ConfigureServices();
 
@@ -76,14 +76,14 @@
             return commandLineBuilder.UseDefaults()
                 .UseExceptionHandler((e, context) =>
                 {
-                    // Unwind to inner mode exception
+                    // Unwind to inner most exception
                     var innerEx = e;
                     while(innerEx.InnerException is not null){
                         innerEx = innerEx.InnerException;
                     }
 
                     switch(innerEx)
-                    {        
+                    {
                         case DirectoryNotFoundException dnfe:
                             WriteError("One or more directories in your config file do not exist", dnfe);
                             break;
@@ -136,9 +136,10 @@
                 })
                 .AddSingleton<IConfiguration>(configuration)
                 .AddSingleton<IWalrusConfig>(p => {
+                    // Load and validation user configuration
                     var config = p.GetRequiredService<IConfiguration>().Get<WalrusConfig>() ??
                                                   WalrusConfig.Default;
-                    config.ValidateOrThrow();            
+                    config.ValidateOrThrow();
                     return config;
                 })
                 .AddTransient<IRepositoryProvider, RepositoryProvider>()

--- a/Walrus.CLI/Walrus.CLI.csproj
+++ b/Walrus.CLI/Walrus.CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <SemVer>0.1.11</SemVer>
+    <SemVer>0.1.12</SemVer>
     <Suffix></Suffix>
   </PropertyGroup>
 

--- a/Walrus.Core.Tests/PathHelperTests.cs
+++ b/Walrus.Core.Tests/PathHelperTests.cs
@@ -1,0 +1,64 @@
+namespace Walrus.Core.Tests
+{
+    using System;
+    using Xunit;
+
+    /// <summary>
+    ///     PathHelper tests
+    /// </summary>
+    public class PathHelperTests
+    {
+        public PathHelperTests()
+        {
+            // setup some env vars
+            Environment.SetEnvironmentVariable("HOME", "/home/user");
+            Environment.SetEnvironmentVariable("FOO", "foo");
+        }
+
+        /// <summary>
+        /// Assert that a path with no variables is not modified
+        /// </summary>
+        [Theory]
+        [InlineData("/absolute/path", "/absolute/path")]
+        [InlineData("relative", "relative")]
+        [InlineData("relative/path/to/boot", "relative/path/to/boot")]
+        [InlineData("relative/path/to/../boot", "relative/path/to/../boot")]
+        public void NoVariablesTest(string input, string expect)
+        {
+            // Execute
+            var resolved = PathHelper.ResolvePath(input);
+
+            // Assert
+            Assert.Equal(expect, resolved);
+        }
+
+        /// <summary>
+        /// Assert that ~/ home resolution works
+        /// </summary>
+        [Theory]
+        [InlineData("~/", "/home/user/")]
+        public void HomeTildaTest(string input, string expect)
+        {
+            // Execute
+            var resolved = PathHelper.ResolvePath(input);
+
+            // Assert
+            Assert.Equal(expect, resolved);
+        }
+
+        /// <summary>
+        /// Assert that ~/ home and env var resolution works
+        /// </summary>
+        [Theory]
+        [InlineData("~/$FOO", "/home/user/foo")]
+        [InlineData("~/%FOO%", "/home/user/foo")]
+        public void HomeVariablesTest(string input, string expect)
+        {
+            // Execute
+            var resolved = PathHelper.ResolvePath(input);
+
+            // Assert
+            Assert.Equal(expect, resolved);
+        }
+    }
+}

--- a/Walrus.Core.Tests/WalrusConfigTests.cs
+++ b/Walrus.Core.Tests/WalrusConfigTests.cs
@@ -1,0 +1,53 @@
+namespace Walrus.Core.Tests
+{
+    using System.Linq;
+    using System.Collections.Generic;
+    using Xunit;
+
+    /// <summary>
+    ///     WalrusConfig tests
+    /// </summary>
+    public class WalrusConfigTests
+    {
+        /// <summary>
+        /// The default configuration should be valid
+        /// </summary>
+        [Fact]
+        public void ValidConfigurationTest()
+        {
+            // Setup
+            var config = WalrusConfig.Default;
+
+            // Execute
+            config.ValidateOrThrow();
+        }
+
+        /// <summary>
+        /// A configuration file with negative scan depth is invalid
+        /// </summary>
+        [Fact]
+        public void NegativeScanDepthTest()
+        {
+            // Setup
+            var config = WalrusConfig.Default;
+            config.DirectoryScanDepth = -1;
+
+            // Execute
+            Assert.Throws<WalrusConfigurationException>(() => config.ValidateOrThrow());
+        }
+
+        /// <summary>
+        /// A configuration file with an empty path is invalid
+        /// </summary>
+        [Fact]
+        public void EmptyPathRootTest()
+        {
+            // Setup
+            var config = WalrusConfig.Default;
+            config.RepositoryRoots.Add(string.Empty);
+
+            // Execute
+            Assert.Throws<WalrusConfigurationException>(() => config.ValidateOrThrow());
+        }
+    }
+}

--- a/Walrus.Core/IWalrusConfig.cs
+++ b/Walrus.Core/IWalrusConfig.cs
@@ -25,5 +25,11 @@ namespace Walrus.Core
         ///     "some name" : { "email1@example.com", "email2@work.com" }
         /// </summary>
         IDictionary<string, IList<string>>? AuthorAliases { get; set; }
+
+        /// <summary>
+        ///     Validates self or throws WalrusConfigurationException
+        /// </summary>
+        /// <exception cref="WalrusConfigurationException">Thrown if configuration is invalid</exception>
+        public void ValidateOrThrow();
     }
 }

--- a/Walrus.Core/IWalrusConfig.cs
+++ b/Walrus.Core/IWalrusConfig.cs
@@ -18,7 +18,7 @@ namespace Walrus.Core
         /// <summary>
         ///     List of repository roots to scan
         /// </summary>
-        IList<string>? RepositoryRoots { get; set; }
+        IList<string> RepositoryRoots { get; set; }
 
         /// <summary>
         ///     List of author aliases

--- a/Walrus.Core/Internal/PreparedWalrusQuery.cs
+++ b/Walrus.Core/Internal/PreparedWalrusQuery.cs
@@ -1,6 +1,7 @@
 ﻿namespace Walrus.Core.Internal
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using Repository;
 
@@ -34,7 +35,8 @@
             }
 
             // If current directory is specified it will override the configured search roots
-            SearchPaths = query.CurrentDirectory ? new[] {Environment.CurrentDirectory} : config.RepositoryRoots;
+            SearchPaths = (query.CurrentDirectory ? new[] {Environment.CurrentDirectory} : config.RepositoryRoots)
+                          .Select(p => PathHelper.ResolvePath(p));
         }
 
         /// <summary>

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -1,0 +1,63 @@
+
+namespace Walrus.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    /// <summary>
+    /// Path helper utilities
+    /// </summary>
+    public static class PathHelper
+    {
+        /// <summary>
+        /// Automatically resolve all environmental variables and
+        /// the home tilda (~/) in path.
+        /// </summary>
+        /// <param name="path">Path to resovle</param>
+        /// <return>Resolved path</return>
+        public static string ResolvePath(string path)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+
+            path = ResolveAllEnvironmentVariables(path);
+
+            if(path.StartsWith("~/"))
+            {
+                var home = Environment.GetEnvironmentVariable("HOME");
+                path = path.Replace("~/", $"{home}{Path.DirectorySeparatorChar}");
+            }
+
+            return path;
+
+        }
+
+        /// <summary>
+        /// Split path into components and resolve them if they're environmental
+        /// variables. It turns out Environment.ExpandEnvironmentVariables does 
+        /// not support the $VAR syntax, only %VAR% syntax.
+        /// </summary>
+        private static string ResolveAllEnvironmentVariables(string path)
+        {
+            var resolved = new List<string>(16);
+            foreach(var part in path.Split(Path.DirectorySeparatorChar))
+            {
+                string expanded = part;
+
+                if(part.StartsWith('$'))
+                {
+                    var varName = part.Substring(1);
+                    expanded = Environment.GetEnvironmentVariable(varName) ?? string.Empty;
+                } 
+                else if(part.StartsWith('%'))
+                {
+                    expanded = Environment.ExpandEnvironmentVariables(part);
+                }
+
+                resolved.Add(expanded);
+            }
+
+            return string.Join(Path.DirectorySeparatorChar, resolved);
+        }
+    }
+}

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -1,4 +1,3 @@
-
 namespace Walrus.Core
 {
     using System;
@@ -21,13 +20,13 @@ namespace Walrus.Core
         {
             ArgumentNullException.ThrowIfNull(path);
 
-            path = ResolveAllEnvironmentVariables(path);
-
-            if(path.StartsWith("~/"))
+            if (path.StartsWith("~/"))
             {
                 var home = Environment.GetEnvironmentVariable("HOME");
                 path = path.Replace("~/", $"{home}{Path.DirectorySeparatorChar}");
             }
+
+            path = ResolveAllEnvironmentVariables(path);
 
             return path;
 
@@ -41,16 +40,16 @@ namespace Walrus.Core
         private static string ResolveAllEnvironmentVariables(string path)
         {
             var resolved = new List<string>(16);
-            foreach(var part in path.Split(Path.DirectorySeparatorChar))
+            foreach (var part in path.Split(Path.DirectorySeparatorChar))
             {
                 string expanded = part;
 
-                if(part.StartsWith('$'))
+                if (part.StartsWith('$'))
                 {
                     var varName = part.Substring(1);
                     expanded = Environment.GetEnvironmentVariable(varName) ?? string.Empty;
                 }
-                else if(part.StartsWith('%'))
+                else if (part.StartsWith('%'))
                 {
                     expanded = Environment.ExpandEnvironmentVariables(part);
                 }

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -8,6 +8,7 @@ namespace Walrus.Core
     /// <summary>
     /// Path helper utilities
     /// </summary>
+    /// <remarks>Nested variables are not supported</remarks>
     public static class PathHelper
     {
         /// <summary>
@@ -34,7 +35,7 @@ namespace Walrus.Core
 
         /// <summary>
         /// Split path into components and resolve them if they're environmental
-        /// variables. It turns out Environment.ExpandEnvironmentVariables does 
+        /// variables. It turns out Environment.ExpandEnvironmentVariables does
         /// not support the $VAR syntax, only %VAR% syntax.
         /// </summary>
         private static string ResolveAllEnvironmentVariables(string path)
@@ -48,7 +49,7 @@ namespace Walrus.Core
                 {
                     var varName = part.Substring(1);
                     expanded = Environment.GetEnvironmentVariable(varName) ?? string.Empty;
-                } 
+                }
                 else if(part.StartsWith('%'))
                 {
                     expanded = Environment.ExpandEnvironmentVariables(part);

--- a/Walrus.Core/WalrusConfig.cs
+++ b/Walrus.Core/WalrusConfig.cs
@@ -1,46 +1,27 @@
 ﻿namespace Walrus.Core
 {
-    using System.Linq;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     /// <summary>
     ///     Walrus service configuration
     /// </summary>
     public sealed class WalrusConfig : IWalrusConfig
     {
-        private IList<string>? _repositoryRoots;
-
         /// <summary>
         ///     Generate a default configuration
         /// </summary>
         public static WalrusConfig Default => new()
         {
-            DirectoryScanDepth = 3,
-            RepositoryRoots = new List<string>(),
-            AuthorAliases = null
+            DirectoryScanDepth = 3
         };
 
         /// <inheritdoc />
         public int DirectoryScanDepth { get; set; }
 
         /// <inheritdoc />
-        public IList<string>? RepositoryRoots
-        {
-            get
-            {   
-                if(_repositoryRoots is null)
-                {
-                    return null;
-                }
-
-                // Return fully resolved paths (i.e. $HOME, %HOME%, ~/ expanded to the absolute path)
-                return new List<string>(_repositoryRoots)
-                    .Select(p => PathHelper.ResolvePath(p))
-                    .ToList();
-            }
-            set => _repositoryRoots = value;
-        }
+        public IList<string> RepositoryRoots { get; set; } = new List<string>();
 
         /// <inheritdoc />
         public IDictionary<string, IList<string>>? AuthorAliases { get; set; }
@@ -50,22 +31,20 @@
         {
             if(DirectoryScanDepth < 0)
             {
-                throw new WalrusConfigurationException("DirectoryScanDepth must be >= 0");
+                throw new WalrusConfigurationException($"{nameof(DirectoryScanDepth)} must be >= 0");
             }
 
-            if(RepositoryRoots is not null)
+            // Be sure to validate against fully resolved paths
+            foreach(var path in RepositoryRoots.Select(p => PathHelper.ResolvePath(p)))
             {
-                foreach(var path in RepositoryRoots)
+                if(string.IsNullOrEmpty(path))
                 {
-                    if(string.IsNullOrEmpty(path))
-                    {
-                        throw new WalrusConfigurationException("RepositoryRoots contains one or more empty paths. Perhaps an env var is misspelled?");
-                    }            
+                    throw new WalrusConfigurationException($"{nameof(RepositoryRoots)} contains one or more empty paths. Perhaps an env var is misspelled?");
+                }
 
-                    if(!Directory.Exists(path))
-                    {
-                        throw new WalrusConfigurationException($"RepositoryRoots contains {path} which does not exist");
-                    }
+                if(!Directory.Exists(path))
+                {
+                    throw new WalrusConfigurationException($"{nameof(RepositoryRoots)} contains {path} which does not exist");
                 }
             }
         }

--- a/Walrus.Core/WalrusConfig.cs
+++ b/Walrus.Core/WalrusConfig.cs
@@ -1,19 +1,23 @@
 ﻿namespace Walrus.Core
 {
+    using System.Linq;
     using System.Collections.Generic;
+    using System.IO;
 
     /// <summary>
     ///     Walrus service configuration
     /// </summary>
     public sealed class WalrusConfig : IWalrusConfig
     {
+        private IList<string>? _repositoryRoots;
+
         /// <summary>
         ///     Generate a default configuration
         /// </summary>
         public static WalrusConfig Default => new()
         {
             DirectoryScanDepth = 3,
-            RepositoryRoots = null,
+            RepositoryRoots = new List<string>(),
             AuthorAliases = null
         };
 
@@ -21,9 +25,49 @@
         public int DirectoryScanDepth { get; set; }
 
         /// <inheritdoc />
-        public IList<string>? RepositoryRoots { get; set; }
+        public IList<string>? RepositoryRoots
+        {
+            get
+            {   
+                if(_repositoryRoots is null)
+                {
+                    return null;
+                }
+
+                // Return fully resolved paths (i.e. $HOME, %HOME%, ~/ expanded to the absolute path)
+                return new List<string>(_repositoryRoots)
+                    .Select(p => PathHelper.ResolvePath(p))
+                    .ToList();
+            }
+            set => _repositoryRoots = value;
+        }
 
         /// <inheritdoc />
         public IDictionary<string, IList<string>>? AuthorAliases { get; set; }
+
+        /// <inheritdoc />
+        public void ValidateOrThrow()
+        {
+            if(DirectoryScanDepth < 0)
+            {
+                throw new WalrusConfigurationException("DirectoryScanDepth must be >= 0");
+            }
+
+            if(RepositoryRoots is not null)
+            {
+                foreach(var path in RepositoryRoots)
+                {
+                    if(string.IsNullOrEmpty(path))
+                    {
+                        throw new WalrusConfigurationException("RepositoryRoots contains one or more empty paths. Perhaps an env var is misspelled?");
+                    }            
+
+                    if(!Directory.Exists(path))
+                    {
+                        throw new WalrusConfigurationException($"RepositoryRoots contains {path} which does not exist");
+                    }
+                }
+            }
+        }
     }
 }

--- a/Walrus.Core/WalrusConfigurationException.cs
+++ b/Walrus.Core/WalrusConfigurationException.cs
@@ -1,0 +1,23 @@
+namespace Walrus.Core
+{
+    using System;
+    
+    /// <inheritdoc />
+    [Serializable]
+    public class WalrusConfigurationException : Exception
+    {
+        /// <inheritdoc />
+        public WalrusConfigurationException() { }
+
+        /// <inheritdoc />
+        public WalrusConfigurationException(string message) : base(message) { }
+
+        /// <inheritdoc />
+        public WalrusConfigurationException(string message, System.Exception inner) : base(message, inner) { }
+
+        /// <inheritdoc />
+        protected WalrusConfigurationException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/Walrus.Core/WalrusService.cs
+++ b/Walrus.Core/WalrusService.cs
@@ -98,6 +98,8 @@
 
             foreach (var root in query.SearchPaths)
             {
+                _logger.LogDebug("Searching {Path}", root);
+
                 var repositories = _repositoryProvider
                     .GetRepositories(root, Config.DirectoryScanDepth, query.AllBranches)
                     .Where(query.IsMatch);


### PR DESCRIPTION
This adds support for config file paths and contents that use ~/ and environmental variables. Note that 
we only support one level of nesting for variables. We could support nested variables but that's more 
work that I want to commit to this at the moment.

This also cleans up some exception handling so the user experience is slightly better in cases of bad 
configuration entries.