### PR TITLE
fix: cherry-pick commit duplication

### DIFF
--- a/Walrus.Core.Tests/MockRepoProvider.cs
+++ b/Walrus.Core.Tests/MockRepoProvider.cs
@@ -78,6 +78,17 @@
                         AuthorEmail = "test2@example.com",
                         RepoName = "project_2",
                         RepoPath = "/home/user/code/project_2"
+                    },
+                    // A cherry-pick
+                    new WalrusCommit
+                    {
+                        Branch = "feature",
+                        Message = "[bugfix] really fix issue #2252",
+                        Sha = "0335f9a11ec0c5f83c0f412ed49e816f815d9089",
+                        Timestamp = ConstantDateTimes.Today,
+                        AuthorEmail = "test2@example.com",
+                        RepoName = "project_2",
+                        RepoPath = "/home/user/code/project_2"
                     }
                 })
             };

--- a/Walrus.Core/Repository/WalrusCommit.cs
+++ b/Walrus.Core/Repository/WalrusCommit.cs
@@ -43,6 +43,28 @@
         public DateTime Timestamp { get; init; }
 
         /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as WalrusCommit);
+        }
+
+        /// <summary>
+        ///     Commits with the same sha from the same repo path are equal
+        /// </summary>
+        public bool Equals(WalrusCommit? other)
+        {
+            return other != null &&
+                Sha == other.Sha &&
+                RepoPath == other.RepoPath;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Sha, RepoPath);
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"[{RepoName}] {Timestamp} {AuthorEmail} {Sha} {Message}";

--- a/Walrus.Core/WalrusService.cs
+++ b/Walrus.Core/WalrusService.cs
@@ -46,7 +46,9 @@
             var commits =
                 QueryRepositories(query)
                     .AsParallel()
-                    .SelectMany(r => r.Commits.Where(preparedQuery.IsMatch));
+                    .SelectMany(r => r.Commits
+                        .Distinct()
+                        .Where(preparedQuery.IsMatch));
 
             // Wrap GroupBy in a CommitGroup so we can have keys of different types
             var grouped = query.GroupBy switch


### PR DESCRIPTION
When commits are cherry picked from another branch they will be reported multiple times. Implement equality interface for WalrusCommit and filter repo commits to Distinct() based on this rule. Commits are equal if they are from the same local repo (by path, not just name) and have matching shas.