### PR TITLE
add exclude specific  repos feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,26 @@ A multi-repo Git query tool
 
 ## Purpose
 
-I spend a fair amount of time tracking down the what and when of my daily activities. Usually this searching spans many (10+) repositories which means the task is boring and tedious. Walrus 
-tool aims to automate the discovery of git commits based on date, author, and other criteria. 
+I spend a fair amount of time tracking down the what and when of my daily activities. Usually this searching spans many (10+) repositories which means the task is boring and tedious. Walrus
+tool aims to automate the discovery of git commits based on date, author, and other criteria.
 
 ## Goals
 
 We don't want to reinvent libgit2sharp, we just want a simple query interface specific to commit messages. We don't care about diffs, code content, or even the change sets.
-For this reason, Gitbase was found to be entirely overkill even though it is pretty rad. It is a fantastic tool and I do make use of it but managing it is kind of a pain. For this reason, the 
+For this reason, Gitbase was found to be entirely overkill even though it is pretty rad. It is a fantastic tool and I do make use of it but managing it is kind of a pain. For this reason, the
 overarching goal of this project is simplicity with the ability to opt-in to complexity when needed.
 
 ## Getting Started
 
 This utility should be used as a dotnet tool. See `tools/install_as_tool.ps1` for how to build and install Walrus on your system.
+
+```
+# Windows
+.\tools\install_as_tool.ps1
+
+# Not Windows
+bash tools/install_as_tool.ps1
+```
 
 To query multiple roots or query from any location, you will need to setup a simple JSON config file. This can be specified as an env `WALRUS_CONFIG_FILE` or a file
 named `walrus.json` placed in your current working directory. The contents should look something like this is:
@@ -26,14 +34,17 @@ named `walrus.json` placed in your current working directory. The contents shoul
 {
   "DirectoryScanDepth": 3,
   "RepositoryRoots": [
-    "H:\\code",
+    "H:\\code"
   ],
   "AuthorAliases": {
-	  "illyum": [
-		  "illy@home.com",
-		  "illy@work.com"
-	  ]
-  }
+      "illyum": [
+          "illy@home.com",
+          "illy@work.com"
+      ]
+  },
+  "IgnorePaths": [
+    "H:\\code\\llvm"
+  ]
 }
 ```
 
@@ -48,7 +59,7 @@ Show the active configuration
 ```
 walrusc show config
 ```
-  
+
 Print a list of all repositories
 ```
 walrusc show repos
@@ -58,12 +69,12 @@ Use the default scan depth and search for repositories relative to your current 
 ```
 walrusc query --current-directory
 ```
-  
+
 Count commits between March 2 and Jun 2 of 2021. This includes all authors on the currently checked out branch in each repository
 ```
 walrusc query --after "Mar 2 2021" --before "Jun 2 2021"
 ```
-  
+
 
 Show all commits on all branches since last week (default if --after is not specified) and restrict to a single author
 ```
@@ -122,8 +133,7 @@ walrusc query --author-alias illyum
 
 - [x] Basic date/author query interface
 - [x] Unit tests
-- [x] Simple CLI 
+- [x] Simple CLI
 - [x] Table style CLI output
 - [x] Create dotnet tool
-- [x] CI tests  
-- [ ] Calendar style GUI 
+- [x] CI tests

--- a/Walrus.CLI/Walrus.CLI.csproj
+++ b/Walrus.CLI/Walrus.CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <SemVer>0.2.0</SemVer>
+    <SemVer>0.3.0</SemVer>
     <Suffix></Suffix>
   </PropertyGroup>
 

--- a/Walrus.Core.Tests/MockRepoProvider.cs
+++ b/Walrus.Core.Tests/MockRepoProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace Walrus.Core.Tests
 {
+    using System;
     using System.Collections.Generic;
     using Repository;
 
@@ -92,6 +93,17 @@
                     }
                 })
             };
+        }
+
+        public IEnumerable<WalrusRepository> GetRepositories(string rootDirectory, int scanDepth, bool allBranches, Predicate<string> excludeFilter = null)
+        {
+            foreach(var repo in GetRepositories(rootDirectory, scanDepth, allBranches))
+            {
+                if (!excludeFilter(repo.RepositoryPath))
+                {
+                    yield return repo;
+                }
+            }
         }
     }
 }

--- a/Walrus.Core.Tests/PathHelperTests.cs
+++ b/Walrus.Core.Tests/PathHelperTests.cs
@@ -23,7 +23,7 @@ namespace Walrus.Core.Tests
                     yield return new object[] { "relative", "relative" };
                     yield return new object[] { @"relative\path\to\boot", @"relative\path\to\boot" };
                     yield return new object[] { @"relative\path\to\..\boot", @"relative\path\to\..\boot" };
-                    yield return new object[] { @"~/", @"C:\Users\user\" };
+                    yield return new object[] { @"~/", @"C:\Users\user" };
                     yield return new object[] { @"~/%FOO%", @"C:\Users\user\foo" };
                 }
                 else
@@ -32,7 +32,7 @@ namespace Walrus.Core.Tests
                     yield return new object[] { "relative", "relative" };
                     yield return new object[] { "relative/path/to/boot", "relative/path/to/boot" };
                     yield return new object[] { "relative/path/to/../boot", "relative/path/to/../boot" };
-                    yield return new object[] { "~/", "/home/user/" };
+                    yield return new object[] { "~/", "/home/user" };
                     yield return new object[] { "~/$FOO", "/home/user/foo" };
                 }
             }

--- a/Walrus.Core.Tests/WalrusConfigTests.cs
+++ b/Walrus.Core.Tests/WalrusConfigTests.cs
@@ -3,6 +3,7 @@ namespace Walrus.Core.Tests
     using System.Linq;
     using System.Collections.Generic;
     using Xunit;
+    using Newtonsoft.Json;
 
     /// <summary>
     ///     WalrusConfig tests
@@ -48,6 +49,34 @@ namespace Walrus.Core.Tests
 
             // Execute
             Assert.Throws<WalrusConfigurationException>(() => config.ValidateOrThrow());
+        }
+
+        /// <summary>
+        /// Allow existing configurations to work without
+        /// specifying a repo ignore list.
+        /// </summary>
+        [Fact]
+        public void MissingIgnoredRepos()
+        {
+            // Setup
+            var json = """
+            {
+                "DirectoryScanDepth": 3,
+                "RepositoryRoots": [
+                    "H:\\code"
+                ],
+                "AuthorAliases": {
+                    "illyum": [
+                        "illy@home.com",
+                        "illy@work.com"
+                    ]
+                }
+            }
+            """;
+
+            // Execute
+            var config = JsonConvert.DeserializeObject<WalrusConfig>(json);
+            Assert.Empty(config.IgnoredRepos);
         }
     }
 }

--- a/Walrus.Core/IWalrusConfig.cs
+++ b/Walrus.Core/IWalrusConfig.cs
@@ -27,6 +27,12 @@ namespace Walrus.Core
         IDictionary<string, IList<string>>? AuthorAliases { get; set; }
 
         /// <summary>
+        ///     List of repository names to ignore
+        ///     This is the full path of the repo to ignore
+        /// </summary>
+        IList<string> IgnoredRepos { get; set; }
+
+        /// <summary>
         ///     Validates self or throws WalrusConfigurationException
         /// </summary>
         /// <exception cref="WalrusConfigurationException">Thrown if configuration is invalid</exception>

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -3,6 +3,8 @@ namespace Walrus.Core
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Path helper utilities
@@ -27,9 +29,40 @@ namespace Walrus.Core
             }
 
             path = ResolveAllEnvironmentVariables(path);
+            path = Normalize(path);
 
             return path;
 
+        }
+
+        internal static string Normalize(string path)
+        {
+            return Path.GetFullPath(path)
+                .Trim()
+                .TrimEnd(Path.DirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="pathList"/> contains <paramref name="repositoryPath"/>.
+        /// All paths are normalized beforce testing.
+        /// </summary>
+        /// <param name="ignoredRepos">List of paths to test against</param>
+        /// <param name="repositoryPath"></param>
+        /// <returns></returns>
+        internal static bool ContainsPath(IList<string> pathList, string repositoryPath)
+        {
+            var found = false;
+            var normalizedTarget = Normalize(repositoryPath);
+            foreach(var ignoredRepo in pathList)
+            {
+                var normalizedIgnore = Normalize(ignoredRepo);
+                found = normalizedTarget == normalizedIgnore;
+                if(found)
+                {
+                    break;
+                }
+            }
+            return found;
         }
 
         /// <summary>

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -16,8 +16,8 @@ namespace Walrus.Core
         /// Automatically resolve all environmental variables and
         /// the home tilda (~/) in path.
         /// </summary>
-        /// <param name="path">Path to resovle</param>
-        /// <return>Resolved path</return>
+        /// <param name="path">Path to resolve</param>
+        /// <return>Absolute resolved path</return>
         public static string ResolvePath(string path)
         {
             ArgumentNullException.ThrowIfNull(path);
@@ -29,22 +29,13 @@ namespace Walrus.Core
             }
 
             path = ResolveAllEnvironmentVariables(path);
-            path = Normalize(path);
 
             return path;
 
         }
 
-        internal static string Normalize(string path)
-        {
-            return Path.GetFullPath(path)
-                .Trim()
-                .TrimEnd(Path.DirectorySeparatorChar);
-        }
-
         /// <summary>
         /// Returns true if <paramref name="pathList"/> contains <paramref name="repositoryPath"/>.
-        /// All paths are normalized beforce testing.
         /// </summary>
         /// <param name="ignoredRepos">List of paths to test against</param>
         /// <param name="repositoryPath"></param>
@@ -52,13 +43,13 @@ namespace Walrus.Core
         internal static bool ContainsPath(IList<string> pathList, string repositoryPath)
         {
             var found = false;
-            var normalizedTarget = Normalize(repositoryPath);
+            var normalizedPath = Path.GetFullPath(ResolvePath(repositoryPath));
             foreach(var ignoredRepo in pathList)
             {
-                var normalizedIgnore = Normalize(ignoredRepo);
-                found = normalizedTarget == normalizedIgnore;
-                if(found)
+                var normalizedIgnoredRepo = Path.GetFullPath(ResolvePath(ignoredRepo));
+                if (normalizedIgnoredRepo == normalizedPath)
                 {
+                    found = true;
                     break;
                 }
             }

--- a/Walrus.Core/PathHelper.cs
+++ b/Walrus.Core/PathHelper.cs
@@ -29,6 +29,7 @@ namespace Walrus.Core
             }
 
             path = ResolveAllEnvironmentVariables(path);
+            path = path.TrimEnd(Path.DirectorySeparatorChar);
 
             return path;
 
@@ -49,6 +50,7 @@ namespace Walrus.Core
                 var normalizedIgnoredRepo = Path.GetFullPath(ResolvePath(ignoredRepo));
                 if (normalizedIgnoredRepo == normalizedPath)
                 {
+                    WalrusLog.Logger.LogDebug("Ignoring repository {RepositoryPath}", repositoryPath);
                     found = true;
                     break;
                 }

--- a/Walrus.Core/Repository/IRepositoryProvider.cs
+++ b/Walrus.Core/Repository/IRepositoryProvider.cs
@@ -14,8 +14,9 @@
         /// <param name="rootDirectory">Directory to search for Git repositories</param>
         /// <param name="scanDepth">Recursively scan to this depth. Must be greater than or equal to zero.</param>
         /// <param name="allBranches">If true, include all branches in commit collection for each repository.</param>
+        /// <param name="excludeFilter">Optional filter returns false for repo paths that should be excluded.</param>
         /// <returns>List of repositories</returns>
         /// <exception cref="ArgumentException"><paramref name="scanDepth" /> is less than 0</exception>
-        IEnumerable<WalrusRepository> GetRepositories(string rootDirectory, int scanDepth, bool allBranches);
+        IEnumerable<WalrusRepository> GetRepositories(string rootDirectory, int scanDepth, bool allBranches, Predicate<string>? excludeFilter =null);
     }
 }

--- a/Walrus.Core/Repository/RepositoryProvider.cs
+++ b/Walrus.Core/Repository/RepositoryProvider.cs
@@ -13,10 +13,13 @@
     public class RepositoryProvider : IRepositoryProvider
     {
         /// <inheritdoc />
-        public IEnumerable<WalrusRepository> GetRepositories(string rootDirectory, int scanDepth, bool allBranches)
+        public IEnumerable<WalrusRepository> GetRepositories(string rootDirectory, int scanDepth, bool allBranches, Predicate<string>? excludeFilter =null)
         {
             Ensure.IsValid(nameof(rootDirectory), !string.IsNullOrEmpty(rootDirectory));
             Ensure.IsValid(nameof(scanDepth), scanDepth >= 0);
+
+            // Accept everything by default
+            excludeFilter ??= (string s) => false;
 
             var directories = Utilities.EnumerateGitDirectoriesToDepth(rootDirectory, scanDepth);
 
@@ -30,6 +33,11 @@
 
                 // If neither the path or the working directory are set
                 Ensure.IsValid(nameof(repoPath), !string.IsNullOrEmpty(repoPath), "Expected a valid repo path to be set. This is a bug.");
+
+                if (excludeFilter(repoPath))
+                {
+                    continue;
+                }
 
                 var commits = GetCommits(repo, allBranches);
 

--- a/Walrus.Core/WalrusConfig.cs
+++ b/Walrus.Core/WalrusConfig.cs
@@ -32,15 +32,8 @@
         /// <inheritdoc />
         public IList<string> IgnoredRepos
         {
-            get => _ignoredRepos;
-            set
-            {
-                _ignoredRepos.Clear();
-                foreach(var path in value)
-                {
-                    _ignoredRepos.Add(PathHelper.ResolvePath(path));
-                }
-            }
+            get => _ignoredRepos.Select(PathHelper.ResolvePath).ToList();
+            set => _ignoredRepos.AddRange(value);
         }
 
         /// <inheritdoc />

--- a/Walrus.Core/WalrusConfig.cs
+++ b/Walrus.Core/WalrusConfig.cs
@@ -9,6 +9,9 @@
     /// </summary>
     public sealed class WalrusConfig : IWalrusConfig
     {
+
+        private readonly List<string> _ignoredRepos = new();
+
         /// <summary>
         ///     Generate a default configuration
         /// </summary>
@@ -25,6 +28,20 @@
 
         /// <inheritdoc />
         public IDictionary<string, IList<string>>? AuthorAliases { get; set; }
+
+        /// <inheritdoc />
+        public IList<string> IgnoredRepos
+        {
+            get => _ignoredRepos;
+            set
+            {
+                _ignoredRepos.Clear();
+                foreach(var path in value)
+                {
+                    _ignoredRepos.Add(PathHelper.ResolvePath(path));
+                }
+            }
+        }
 
         /// <inheritdoc />
         public void ValidateOrThrow()

--- a/Walrus.Core/WalrusService.cs
+++ b/Walrus.Core/WalrusService.cs
@@ -14,6 +14,7 @@
     {
         private readonly ILogger _logger;
         private readonly IRepositoryProvider _repositoryProvider;
+        private readonly ISet<string> _ignoredPaths;
 
         /// <summary>
         ///     Create a new WalrusService
@@ -31,6 +32,7 @@
             _logger = logger;
             _repositoryProvider = repositoryProvider;
             Config = config;
+            _ignoredPaths = new HashSet<string>(Config.IgnoredRepos);
         }
 
         /// <inheritdoc />
@@ -103,7 +105,7 @@
                 _logger.LogDebug("Searching {Path}", root);
 
                 var repositories = _repositoryProvider
-                    .GetRepositories(root, Config.DirectoryScanDepth, query.AllBranches)
+                    .GetRepositories(root, Config.DirectoryScanDepth, query.AllBranches, ExcludeReposFilter)
                     .Where(query.IsMatch);
 
                 foreach (var repo in repositories)
@@ -112,5 +114,7 @@
                 }
             }
         }
+
+        private bool ExcludeReposFilter(string repoPath) => PathHelper.ContainsPath(Config.IgnoredRepos, repoPath);
     }
 }

--- a/samples/walrus.json
+++ b/samples/walrus.json
@@ -4,9 +4,12 @@
     "H:\\code"
   ],
   "AuthorAliases": {
-	  "illyum": [
-		  "illy@home.com",
-		  "illy@work.com"
-	  ]
-  }
+      "illyum": [
+          "illy@home.com",
+          "illy@work.com"
+      ]
+  },
+  "IgnorePaths": [
+    "H:\\code\\llvm"
+  ]
 }


### PR DESCRIPTION
Allow ignoring  repos by direct path. Excluding entire directories ( e.g. common parent ) is not supported.

```
~/code/home/foo
~/code/home/bar
~/code/home/llvm
~/code/work/baz
```

Ignoring ~/code/home/llvm will work but ignoring ~/code/work will exclude ~/code/work/baz.